### PR TITLE
feature/1/회원가입-로그인-로그아웃 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/bangchef/recipe_platform/RecipePlatformApplication.java
+++ b/src/main/java/com/bangchef/recipe_platform/RecipePlatformApplication.java
@@ -2,6 +2,7 @@ package com.bangchef.recipe_platform;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class RecipePlatformApplication {

--- a/src/main/java/com/bangchef/recipe_platform/RecipePlatformApplication.java
+++ b/src/main/java/com/bangchef/recipe_platform/RecipePlatformApplication.java
@@ -2,7 +2,6 @@ package com.bangchef.recipe_platform;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class RecipePlatformApplication {

--- a/src/main/java/com/bangchef/recipe_platform/common/enums/Role.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/enums/Role.java
@@ -1,0 +1,5 @@
+package com.bangchef.recipe_platform.common.enums;
+
+public enum Role {
+    USER, ADMIN, CHEF
+}

--- a/src/main/java/com/bangchef/recipe_platform/common/exception/CustomException.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/exception/CustomException.java
@@ -1,0 +1,33 @@
+package com.bangchef.recipe_platform.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+    private final HttpStatus status;
+
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.status = errorCode.getStatus();
+    }
+
+
+    // CustomException 생성자
+    public CustomException(ErrorCode errorCode, HttpStatus status) {
+        super(errorCode.getMessage()); // ErrorCode에서 메시지를 가져옴
+        this.errorCode = errorCode;
+        this.status = status;
+    }
+
+    // 필요 시 메시지와 에러 코드를 받는 생성자
+    public CustomException(String message, ErrorCode errorCode, HttpStatus status) {
+        super(message);
+        this.errorCode = errorCode;
+        this.status = status;
+    }
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorCode.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.bangchef.recipe_platform.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    //일반
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+
+
+
+    // 유저 관련
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 로그인된 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    ALREADY_LOGGED_IN(HttpStatus.CONFLICT, "이미 로그인된 사용자입니다. 로그아웃 후 다시 시도해주세요."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 메일 인증 관련
+    EMAIL_VERIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 인증에 실패했습니다."),
+    EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다."),
+    EMAIL_SEND_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."); // 반드시 정의되어 있어야 함
+
+
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorResponse.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.bangchef.recipe_platform.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int status;
+    private final String error;
+    private final String message;
+    private final String path;
+
+    public static ErrorResponse of(ErrorCode errorCode, String path) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .error(errorCode.getStatus().name())
+                .message(errorCode.getMessage())
+                .path(path)
+                .build();
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.bangchef.recipe_platform.common.exception;
+
+import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // CustomException 처리
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(
+            CustomException e, HttpServletRequest request) {
+        log.error("CustomException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(
+                e.getErrorCode(),
+                request.getRequestURI()
+        );
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(MessagingException.class)
+    protected ResponseEntity<ErrorResponse> handleMessagingException(
+            MessagingException e, HttpServletRequest request) {
+        log.error("MessagingException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(
+                ErrorCode.EMAIL_SEND_FAILURE,
+                request.getRequestURI()
+        );
+        return ResponseEntity
+                .status(ErrorCode.EMAIL_SEND_FAILURE.getStatus())
+                .body(response);
+    }
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/CustomLogoutFilter.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/CustomLogoutFilter.java
@@ -1,0 +1,136 @@
+package com.bangchef.recipe_platform.security;
+
+import com.bangchef.recipe_platform.security.token.repository.RefreshTokenRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JWTUtil jwtUtil;
+
+    public CustomLogoutFilter(JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response,
+                          FilterChain filterChain) throws IOException, ServletException {
+
+        // 로그아웃 경로와 메서드 검증
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/users\\/logout$")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("DELETE")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Get refresh token from cookies
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
+            }
+        }
+
+        // refresh token null check
+        if (refresh == null) {
+            sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, "Refresh token is missing");
+            return;
+        }
+
+        // 만료 체크
+        try {
+            if (jwtUtil.isExpired(refresh)) {
+                sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, "Refresh token is expired");
+                return;
+            }
+        } catch (ExpiredJwtException e) {
+            sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, "Refresh token is expired");
+            return;
+        }
+
+        // 토큰이 refresh인지 확인
+        String tokenType = jwtUtil.getTokenType(refresh);
+        if (!tokenType.equals("refresh")) {
+            sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "Invalid token type");
+            return;
+        }
+
+        // DB에 저장되어 있는지 확인
+        Boolean isExist = refreshTokenRepository.existsByRefresh(refresh);
+        if (!isExist) {
+            sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST,
+                    "Refresh token does not exist");
+            return;
+        }
+
+        // 로그아웃 진행: Refresh 토큰 DB에서 제거
+        Long userId = jwtUtil.getUserId(refresh);
+        refreshTokenRepository.deleteByUserId(userId);
+
+        // Refresh 토큰 쿠키 삭제
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        sendSuccessResponse(response, "Successfully logged out");
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, int statusCode, String message)
+            throws IOException {
+        response.setStatus(statusCode);
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> errorData = new HashMap<>();
+        errorData.put("status", statusCode);
+        errorData.put("error", message);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String responseBody = objectMapper.writeValueAsString(errorData);
+
+        response.getWriter().write(responseBody);
+    }
+
+    private void sendSuccessResponse(HttpServletResponse response, String message)
+            throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> successData = new HashMap<>();
+        successData.put("status", HttpServletResponse.SC_OK);
+        successData.put("message", message);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String responseBody = objectMapper.writeValueAsString(successData);
+
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/JWTFilter.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/JWTFilter.java
@@ -1,0 +1,88 @@
+package com.bangchef.recipe_platform.security;
+
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(UserRepository userRepository, JWTUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws IOException, ServletException {
+        log.debug("JWTFilter 실행 중");
+
+        String requestURI = request.getRequestURI();
+        if (requestURI.equals("/users/login") || requestURI.equals("/users/join") || requestURI.equals(
+                "/token/reissue")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = request.getHeader("Authorization");
+        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        accessToken = accessToken.substring(7);
+        log.debug("Extracted JWT Token: {}", accessToken);
+        try {
+            if (jwtUtil.isExpired(accessToken)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().print("Access token is expired");
+                return;
+            }
+
+            if (!jwtUtil.getTokenType(accessToken).equals("access")) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().print("Invalid access token");
+                return;
+            }
+
+            Long userId = jwtUtil.getUserId(accessToken);
+            User user = userRepository.findByUserId(userId)
+                    .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+
+            // 여기서 권한 확인
+            String role = jwtUtil.getRole(accessToken);
+            log.debug("Token Role: {}", role); // ADMIN 권한 확인
+            if (!role.equals("USER") && !role.equals("ADMIN")) {
+                log.debug("권한 부족: USER 또는 ADMIN 권한이 아님");
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                response.getWriter().print("Forbidden: USER 또는 ADMIN 권한 필요");
+                return;
+            }
+        } catch (ExpiredJwtException e) {
+            log.error("토큰 만료: ", e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().print("Access token expired");
+            return;
+        } catch (JwtException e) {
+            log.error("JWT 오류: ", e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().print("Invalid JWT token");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/JWTUtil.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/JWTUtil.java
@@ -1,0 +1,79 @@
+package com.bangchef.recipe_platform.security;
+
+import com.bangchef.recipe_platform.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private final Key key;
+
+    // 생성자: Base64로 인코딩된 시크릿을 디코딩해서 사용
+    public JWTUtil(@Value("${spring.jwt.secret}") String secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);  // Base64 디코딩
+        this.key = Keys.hmacShaKeyFor(keyBytes); // 키 생성
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+
+    // User ID 추출
+    public Long getUserId(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("userid", Long.class);
+    }
+
+    // 토큰 타입 추출
+    public String getTokenType(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("tokenType", String.class);
+    }
+
+
+    // Role 추출
+    public String getRole(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("role", String.class);
+    }
+
+    // 토큰 만료 여부 확인
+    public boolean isExpired(String token) {
+        try {
+            Claims claims = getClaims(token);
+            return claims.getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            // JWT가 만료된 경우 예외가 발생하므로, true 반환
+            return true;
+        }
+    }
+
+    // 토큰 생성
+    public String createJwt(String tokenType, User user, String role, Long expiredMs) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expiredMs);
+
+        return Jwts.builder()
+                .claim("tokenType", tokenType)
+                .claim("userid", user.getUserId())
+                .claim("role", role)
+                .setIssuedAt(now)  //
+                .setExpiration(expiration)  //
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/LoginFilter.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/LoginFilter.java
@@ -60,7 +60,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             ObjectMapper mapper = new ObjectMapper();
             LoginDto loginDTO = mapper.readValue(json.toString(), LoginDto.class);
 
-            String username = loginDTO.getUsername();
+            String username = loginDTO.getEmail();
             String password = loginDTO.getPassword();
 
             if (username == null || username.isEmpty()) {

--- a/src/main/java/com/bangchef/recipe_platform/security/LoginFilter.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/LoginFilter.java
@@ -1,0 +1,195 @@
+package com.bangchef.recipe_platform.security;
+
+import com.bangchef.recipe_platform.common.exception.CustomException;
+import com.bangchef.recipe_platform.common.exception.ErrorCode;
+import com.bangchef.recipe_platform.security.token.entity.RefreshToken;
+import com.bangchef.recipe_platform.security.token.repository.RefreshTokenRepository;
+import com.bangchef.recipe_platform.user.dto.CustomUserDetails;
+import com.bangchef.recipe_platform.user.dto.LoginDto;
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil,
+                       RefreshTokenRepository refreshTokenRepository, UserRepository userRepository) {
+        super.setAuthenticationManager(authenticationManager);
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.setFilterProcessesUrl("/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) {
+        try {
+            BufferedReader reader = request.getReader();
+            StringBuilder json = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                json.append(line);
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            LoginDto loginDTO = mapper.readValue(json.toString(), LoginDto.class);
+
+            String username = loginDTO.getUsername();
+            String password = loginDTO.getPassword();
+
+            if (username == null || username.isEmpty()) {
+                log.warn("로그인 실패: 아이디가 비어있습니다.");
+                throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, HttpStatus.BAD_REQUEST);
+            }
+
+            UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(
+                    username, password);
+            return this.getAuthenticationManager().authenticate(authRequest);
+        } catch (IOException e) {
+            log.error("로그인 요청 데이터 처리 중 오류 발생: {}", e.getMessage());
+            try {
+                handleException(response, new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+            return null;
+        } catch (AuthenticationException ex) {
+            log.warn("잘못된 로그인 시도: {}", ex.getMessage());
+            try {
+                handleException(response, new CustomException(ErrorCode.INVALID_CREDENTIALS));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain chain, Authentication authentication) throws IOException {
+        try {
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            User user = userDetails.getUser();
+            Long userId = user.getUserId();
+            Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+
+            if (user == null || userId == null) {
+                log.error("User 객체가 null이거나 userId가 설정되지 않았습니다.");
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
+
+            boolean refreshTokenExists = refreshTokenRepository.existsByUser_UserId(userId);
+            if (refreshTokenExists) {
+                log.warn("중복된 로그인 시도가 감지되었습니다. 사용자 ID: {}", userId);
+                throw new CustomException(ErrorCode.USER_ALREADY_EXISTS, ErrorCode.USER_ALREADY_EXISTS.getStatus());
+            }
+
+            String role = authorities.iterator().next().getAuthority();
+            if (role == null) {
+                log.error("User 권한 정보가 null입니다.");
+                throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
+
+            refreshTokenRepository.deleteByUserId(userId);
+            String accessToken = jwtUtil.createJwt("access", user, role,
+                    Duration.ofMinutes(10).toMillis());
+            String refreshToken = jwtUtil.createJwt("refresh", user, role, Duration.ofDays(7).toMillis());
+
+            log.info("Access Token 생성 완료: {}", accessToken);
+            log.info("Refresh Token 생성 완료: {}", refreshToken);
+
+            addRefreshToken(user, refreshToken, Duration.ofDays(7).toMillis());
+
+            Map<String, String> tokens = new HashMap<>();
+            tokens.put("accessToken", accessToken);
+
+            response.addCookie(createCookie("refresh", refreshToken));
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+
+            new ObjectMapper().writeValue(response.getWriter(), tokens);
+            response.setStatus(HttpStatus.OK.value());
+        } catch (CustomException ex) {
+            handleException(response, ex);
+        } catch (Exception e) {
+            log.error("예기치 않은 오류 발생: {}", e.getMessage());
+            handleException(response,
+                    new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void handleException(HttpServletResponse response, CustomException ex)
+            throws IOException {
+        response.setStatus(ex.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("status", ex.getStatus().value());
+        responseBody.put("error", ex.getErrorCode().getMessage());
+
+        String jsonResponse = new ObjectMapper().writeValueAsString(responseBody);
+        response.getWriter().write(jsonResponse);
+    }
+
+    private void addRefreshToken(User user, String refreshToken, Long expiredMs) {
+        Date expirationDate = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshToken refreshTokenEntity = new RefreshToken();
+        refreshTokenEntity.setUser(user);
+        refreshTokenEntity.setRefresh(refreshToken);
+        refreshTokenEntity.setExpiration(expirationDate.toString());
+
+        refreshTokenRepository.save(refreshTokenEntity);
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        return cookie;
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+                                              HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException {
+        log.warn("로그인 실패: {}", failed.getMessage());
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "Authentication failed");
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        new ObjectMapper().writeValue(response.getWriter(), error);
+    }
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/SecurityConfig.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/SecurityConfig.java
@@ -1,0 +1,96 @@
+package com.bangchef.recipe_platform.security;
+
+import com.bangchef.recipe_platform.security.token.repository.RefreshTokenRepository;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final UserRepository userRepository;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil,
+                          RefreshTokenRepository refreshTokenRepository, UserRepository userRepository) {
+
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.userRepository = userRepository;
+
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+            throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf((auth) -> auth.disable());
+
+        http
+                .formLogin((auth) -> auth.disable()); //
+
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        http
+                .authorizeHttpRequests((auth) -> auth
+
+                        .requestMatchers("/user/**").hasAuthority("USER")
+
+                        .requestMatchers(
+                                "/",
+                                "/users/logout",
+                                "/users/login",
+                                "/users/join",
+                                "users/verify/**",
+                                "/h2-console/**" //서브경로 포함
+                        ).permitAll()
+
+                        .anyRequest().authenticated());
+
+        http
+                .headers(headers -> headers.frameOptions(frame -> frame.disable())); // 프레임 옵션 비활성화
+
+        http
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil,
+                                refreshTokenRepository, userRepository),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .addFilterBefore(new JWTFilter(userRepository, jwtUtil),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshTokenRepository),
+                        LogoutFilter.class);
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/token/controller/ReissueController.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/token/controller/ReissueController.java
@@ -1,0 +1,38 @@
+package com.bangchef.recipe_platform.security.token.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import com.bangchef.recipe_platform.security.token.service.TokenService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/token")
+public class ReissueController {
+    private final TokenService tokenService;
+
+    public ReissueController(TokenService tokenService) {
+        this.tokenService = tokenService;
+
+    }
+
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+        ResponseEntity<?> result = tokenService.reissueToken(request, response);
+
+        // 토큰이 성공적으로 갱신되었다면  바디엑세스 추가
+        if (result.getStatusCode() == HttpStatus.OK) {
+            String newAccessToken = (String) result.getBody();
+            return ResponseEntity.ok().body(Map.of("access_token", newAccessToken));
+
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/token/entity/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.bangchef.recipe_platform.security.token.entity;
+
+import com.bangchef.recipe_platform.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Entity
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long tokenId;
+
+
+    private String refresh;
+
+    private String expiration; // 만료시간
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package com.bangchef.recipe_platform.security.token.repository;
+
+import com.bangchef.recipe_platform.security.token.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Boolean existsByRefresh(String refresh);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RefreshToken rt WHERE rt.user.userId = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+
+    boolean existsByUser_UserId(Long userId);
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/token/service/TokenService.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/token/service/TokenService.java
@@ -1,0 +1,125 @@
+package com.bangchef.recipe_platform.security.token.service;
+
+import com.bangchef.recipe_platform.security.JWTUtil;
+import com.bangchef.recipe_platform.security.token.entity.RefreshToken;
+import com.bangchef.recipe_platform.security.token.repository.RefreshTokenRepository;
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+@Service
+public class TokenService {
+    private final JWTUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenService(JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository,
+                        UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public ResponseEntity<?> reissueToken(HttpServletRequest request, HttpServletResponse response) {
+        String refresh = extractRefreshTokenFromCookies(request);
+
+        if (refresh == null) { // 리프레시 토큰이 비어있다면
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        // 리프레시 토큰 만료 확인
+        if (isTokenExpired(refresh)) {
+            return new ResponseEntity<>("refresh token expired", HttpStatus.BAD_REQUEST);
+        }
+
+        // 토큰이 refresh인지 확인
+        if (!isRefreshToken(refresh)) {
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        // DB에 저장되어 있는지 확인
+        if (!refreshTokenRepository.existsByRefresh(refresh)) {
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        // 유저 정보 확인 및 새로운 토큰 발급
+        Long userId = jwtUtil.getUserId(refresh);
+        String role = jwtUtil.getRole(refresh);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // 새로운 access 및 refresh 토큰 발급
+        String newAccess = jwtUtil.createJwt("access", user, role, 600000L); // 10분
+        String newRefresh = jwtUtil.createJwt("refresh", user, role, 604800000L); // 7일
+
+        // 기존 refresh 토큰 삭제 후 새 토큰 저장
+        refreshTokenRepository.deleteByUserId(userId);
+        //refreshTokenRepository.deleteByRefresh(refresh);
+        saveRefreshToken(user, newRefresh, 604800000L); // 새로운 refresh 토큰 저장
+
+        // 갱신된 토큰을 응답으로 전송
+        response.setHeader("access", newAccess);
+        response.addCookie(createCookie("refresh", newRefresh));
+
+        return new ResponseEntity<>(newAccess, HttpStatus.OK);
+    }
+
+    // 쿠키에서 refresh 토큰 추출
+    private String extractRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    // 토큰 만료 여부 확인
+    private boolean isTokenExpired(String token) {
+        try {
+            jwtUtil.isExpired(token);
+            return false;
+        } catch (ExpiredJwtException e) {
+            System.out.println("토큰이 만료되었습니다:" + token);
+            return true;
+        }
+    }
+
+    // refresh 토큰 여부 확인
+    private boolean isRefreshToken(String token) {
+        return "refresh".equals(jwtUtil.getTokenType(token));
+    }
+
+    // Refresh 토큰 저장
+    @Transactional
+    private void saveRefreshToken(User user, String refreshToken, Long expiredMs) {
+        Date expirationDate = new Date(System.currentTimeMillis() + expiredMs);
+        RefreshToken refreshTokenEntity = new RefreshToken();
+        refreshTokenEntity.setUser(user);
+        refreshTokenEntity.setRefresh(refreshToken);
+        refreshTokenEntity.setExpiration(expirationDate.toString());
+
+        refreshTokenRepository.save(refreshTokenEntity);
+    }
+
+    // 쿠키 생성 메서드
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60); // 하루
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/controller/JoinController.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/controller/JoinController.java
@@ -1,0 +1,30 @@
+package com.bangchef.recipe_platform.user.controller;
+
+
+import com.bangchef.recipe_platform.user.dto.JoinDto;
+import com.bangchef.recipe_platform.user.service.JoinService;
+import jakarta.mail.MessagingException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ResponseBody
+public class JoinController {
+
+    private final JoinService joinService;
+
+    public JoinController(JoinService joinService) {
+
+        this.joinService = joinService;
+
+    }
+
+    @PostMapping("/users/join")
+    public ResponseEntity<String> join(@RequestBody JoinDto joinDto) throws MessagingException {
+        joinService.joinProcess(joinDto);
+        return ResponseEntity.ok("회원가입되었습니다. 이메일 인증을 마쳐주세요.");
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/controller/LogoutController.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/controller/LogoutController.java
@@ -1,0 +1,79 @@
+package com.bangchef.recipe_platform.user.controller;
+
+import com.bangchef.recipe_platform.security.JWTUtil;
+import com.bangchef.recipe_platform.security.token.repository.RefreshTokenRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping ("/users") // 기본 경로 설정
+public class LogoutController {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JWTUtil jwtUtil;
+
+    public LogoutController(JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @DeleteMapping("/logout")
+    @Transactional // 트랜잭션 처리
+    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refresh = getRefreshTokenFromCookies(request);
+
+        // Refresh 토큰 null 체크
+        if (refresh == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token is null");
+        }
+
+        // 만료 체크
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token is expired");
+        }
+
+        // DB에서 Refresh 토큰 존재 여부 확인
+        if (!refreshTokenRepository.existsByRefresh(refresh)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Refresh token does not exist");
+        }
+
+        // Refresh 토큰 DB에서 제거
+        Long userId = jwtUtil.getUserId(refresh);
+        refreshTokenRepository.deleteByUserId(userId);
+
+        // 쿠키 삭제
+        deleteRefreshCookie(response);
+
+        return ResponseEntity.ok("Successfully logged out");
+    }
+
+    // 쿠키에서 Refresh 토큰 가져오기
+    private String getRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    // 쿠키 삭제 메서드
+    private void deleteRefreshCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/controller/VerificationController.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/controller/VerificationController.java
@@ -1,0 +1,33 @@
+package com.bangchef.recipe_platform.user.controller;
+
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+public class VerificationController {
+
+    private final UserRepository userRepository;
+
+    public VerificationController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/verify")
+    public ResponseEntity<String> verifyUser(@RequestParam("token") String token) {
+        User user = userRepository.findByVerificationToken(token)
+                .orElseThrow(() -> new RuntimeException("Invalid verification token"));
+
+        user.setEnabled(true); // 계정 활성화
+        user.setVerificationToken(null); // 토큰 제거
+        userRepository.save(user);
+
+        return ResponseEntity.ok("이메일 인증이 완료되었습니다!");
+    }
+}
+

--- a/src/main/java/com/bangchef/recipe_platform/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/dto/CustomUserDetails.java
@@ -1,0 +1,79 @@
+package com.bangchef.recipe_platform.user.dto;
+
+
+import com.bangchef.recipe_platform.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+    // User 객체를 반환하는 메서드 추가
+    private final User user;
+
+    public CustomUserDetails(User user) {
+
+        this.user = user;
+
+
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(() -> user.getRole().toString());
+    }
+
+    public long getUserId() {
+
+        return user.getUserId();
+    }
+
+    @Override
+    public String getPassword() {
+
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+
+        return user.getUsername();
+    }
+
+    public String getEmail() {
+        return user.getEmail(); // 이메일 반환
+    }
+
+    public String getRole() {
+        return user.getRole().toString(); // 권한 반환
+    }
+
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/dto/JoinDto.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/dto/JoinDto.java
@@ -1,0 +1,20 @@
+package com.bangchef.recipe_platform.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class JoinDto {
+
+    private String username;
+
+    private String password;
+
+    private String email;
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/dto/LoginDto.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/dto/LoginDto.java
@@ -11,6 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class LoginDto {
 
-    private String username;
+    private String email;
     private String password;
 }

--- a/src/main/java/com/bangchef/recipe_platform/user/dto/LoginDto.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/dto/LoginDto.java
@@ -1,0 +1,16 @@
+package com.bangchef.recipe_platform.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginDto {
+
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/entity/Role.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.bangchef.recipe_platform.user.entity;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/entity/Role.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/entity/Role.java
@@ -1,5 +1,0 @@
-package com.bangchef.recipe_platform.user.entity;
-
-public enum Role {
-    USER, ADMIN
-}

--- a/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
@@ -1,0 +1,79 @@
+package com.bangchef.recipe_platform.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(name = "username", nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "email", nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(name = "profile_image", length = 255)
+    private String profileImage;
+
+    @Column(name = "introduction", columnDefinition = "TEXT")
+    private String introduction;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Column(nullable = false)
+    private boolean enabled = false; // 초기 비활성화 상태
+
+    @Column(unique = true)
+    private String verificationToken; // 이메일 인증 토큰
+
+//    // toString 메서드 (옵션)
+//    @Override
+//    public String toString() {
+//        return "User{" +
+//                "id=" + id +
+//                ", username='" + username + '\'' +
+//                ", email='" + email + '\'' +
+//                ", role=" + role +
+//                ", profileImage='" + profileImage + '\'' +
+//                ", introduction='" + introduction + '\'' +
+//                ", createdAt=" + createdAt +
+//                ", updatedAt=" + updatedAt +
+//                '}';
+//    }
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.bangchef.recipe_platform.user.entity;
 
+import com.bangchef.recipe_platform.common.enums.Role;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +14,6 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "users")
 public class User {
 
     @Id

--- a/src/main/java/com/bangchef/recipe_platform/user/repository/UserRepository.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.bangchef.recipe_platform.user.repository;
+
+import com.bangchef.recipe_platform.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+
+    Optional<User> findByUsername(String username);
+    Optional<User> findByUserId(Long userId);
+
+    Optional<User> findByVerificationToken(String token);
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/CustomUserDetailsService.java
@@ -1,0 +1,39 @@
+package com.bangchef.recipe_platform.user.service;
+
+
+import com.bangchef.recipe_platform.user.dto.CustomUserDetails;
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+
+        User user = userRepository.findByUsername(username)
+
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을수없습니다." + username));
+
+        return new CustomUserDetails(user);
+
+    }
+}
+

--- a/src/main/java/com/bangchef/recipe_platform/user/service/EmailService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/EmailService.java
@@ -1,0 +1,33 @@
+package com.bangchef.recipe_platform.user.service;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+@Service
+public class EmailService {
+    private final JavaMailSender mailSender;
+
+    public EmailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendVerificationEmail(String recipientEmail, String token) throws MessagingException {
+        String subject = "이메일 인증 요청";
+        String verificationUrl = "http://localhost:8080/users/verify?token=" + token;
+        String message = "<h1>이메일 인증</h1>" +
+                "<p>아래 링크를 클릭하여 이메일 인증을 완료해주세요:</p>" +
+                "<a href=\"" + verificationUrl + "\">이메일 인증하기</a>";
+
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
+        helper.setTo(recipientEmail);
+        helper.setSubject(subject);
+        helper.setText(message, true); // HTML 형식 허용
+
+        mailSender.send(mimeMessage);
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/service/JoinService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/JoinService.java
@@ -1,0 +1,67 @@
+package com.bangchef.recipe_platform.user.service;
+
+import com.bangchef.recipe_platform.user.dto.JoinDto;
+import com.bangchef.recipe_platform.user.entity.Role;
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import com.bangchef.recipe_platform.user.service.EmailService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.mail.MessagingException;
+import java.util.UUID;
+
+@Service
+public class JoinService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final EmailService emailService;
+
+    public JoinService(UserRepository userRepository, BCryptPasswordEncoder bCryptPasswordEncoder, EmailService emailService) {
+        this.userRepository = userRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.emailService = emailService;
+    }
+
+    @Transactional
+    public void joinProcess(JoinDto joinDto) throws MessagingException {
+        String username = joinDto.getUsername();
+        String password = joinDto.getPassword();
+        String email = joinDto.getEmail();
+
+        if (password == null || password.trim().isEmpty()) {
+            throw new IllegalArgumentException("비밀번호는 필수 입력 사항입니다.");
+        }
+
+        boolean isUsernameExist = userRepository.existsByUsername(username);
+        boolean isEmailExist = userRepository.existsByEmail(email);
+
+        if (isUsernameExist) {
+            throw new RuntimeException("이미 등록된 아이디입니다.");
+        }
+        if (isEmailExist) {
+            throw new RuntimeException("이미 등록된 이메일입니다.");
+        }
+
+        // 유저 데이터 생성
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(bCryptPasswordEncoder.encode(password));
+        user.setEmail(email);
+        user.setRole(Role.USER);
+        user.setEnabled(false); // 초기 상태는 비활성화
+
+        // 인증 토큰 생성
+        String token = UUID.randomUUID().toString();
+        user.setVerificationToken(token);
+
+        // 유저 저장
+        userRepository.save(user);
+
+        // 이메일 발송
+        emailService.sendVerificationEmail(email, token);
+    }
+}
+

--- a/src/main/java/com/bangchef/recipe_platform/user/service/JoinService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/JoinService.java
@@ -1,10 +1,9 @@
 package com.bangchef.recipe_platform.user.service;
 
 import com.bangchef.recipe_platform.user.dto.JoinDto;
-import com.bangchef.recipe_platform.user.entity.Role;
+import com.bangchef.recipe_platform.common.enums.Role;
 import com.bangchef.recipe_platform.user.entity.User;
 import com.bangchef.recipe_platform.user.repository.UserRepository;
-import com.bangchef.recipe_platform.user.service.EmailService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +38,7 @@ public class JoinService {
         boolean isEmailExist = userRepository.existsByEmail(email);
 
         if (isUsernameExist) {
-            throw new RuntimeException("이미 등록된 아이디입니다.");
+            throw new RuntimeException("이미 등록된 닉네임입니다.");
         }
         if (isEmailExist) {
             throw new RuntimeException("이미 등록된 이메일입니다.");

--- a/src/main/java/com/bangchef/recipe_platform/user/service/UserService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/UserService.java
@@ -1,0 +1,46 @@
+package com.bangchef.recipe_platform.user.service;
+
+import com.bangchef.recipe_platform.security.JWTUtil;
+import com.bangchef.recipe_platform.security.token.repository.RefreshTokenRepository;
+import com.bangchef.recipe_platform.user.dto.LoginDto;
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder; // 비밀번호 암호화를 위한 인코더 추가
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository; // 리프레시 토큰 저장소 추가
+
+    @Value("1")
+    private Long jwtExpiration;
+
+    public UserService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder,
+                       JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenRepository = refreshTokenRepository;
+
+    }
+
+    // 로그인 로직: DB에서 사용자 정보 조회 후 JWT 발급
+    public String loginUser(LoginDto loginDto) {
+        User user = userRepository.findByUsername(loginDto.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(loginDto.getPassword(), user.getPassword())) {
+            throw new RuntimeException("Invalid credentials");
+        }
+
+        // 최신 권한을 DB에서 조회하여 토큰 생성
+        String role = user.getRole().toString();
+        return jwtUtil.createJwt("access", user, role, jwtExpiration);
+    }
+
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/service/UserService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
 
     // 로그인 로직: DB에서 사용자 정보 조회 후 JWT 발급
     public String loginUser(LoginDto loginDto) {
-        User user = userRepository.findByUsername(loginDto.getUsername())
+        User user = userRepository.findByUsername(loginDto.getEmail())
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         // 비밀번호 확인

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: recipe-platform
+  jwt:
+    secret: vmfhaadadadaddaddadltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalqwerqwerqwer
+
   h2:
     console:
       enabled: true
@@ -15,3 +18,21 @@ spring:
     url: jdbc:h2:mem:bangchef
     username: sa
     password:
+
+  mail:
+    host: smtp.gmail.com #gmail의 smtp 서버 호스트
+    port: 587 #gmail의 smtp 서버 포트
+    username: projectversionmail@gmail.com
+    password: cyho ciwx anmb niqi
+    protocol: smtp
+    properties:
+      mail:
+        smtp:
+          auth: true # smtp 서버에 인증 필요한 경우 true 로 지정. gmail은 요구함
+          starttls:
+            enable: true # smtp 서버가 tls를 사용하여 안전한 연결을 요구하는 경우
+            required: true
+          connectiontimeout: 5000 # 클라이언트가 smtp 서버와 연결을 설정하는 데 대기해야하는 시간
+          timeout: 5000 # 클라이언트가 smtp 서버로부터 응답을 대기해야하는 시간
+          writetimeout: 5000 # 클라이언트가 작업을 완료하는데 대기해아하는 시간
+    auth-code-expiration-millis: 18000 # 30 * 60 *1000 =30분 이메일 인증 코드의 만료시간


### PR DESCRIPTION
## 추가 사항
- 회원가입과 로그인, 로그아웃 구현을 위한 Entity / Repository / Service / DTO / Controller 생성
- 오류를 담당하는 Entity / Exception ( GlobalExceptionHandler / ErrorResponse / ErrorCode / CustomException) 생성
- SecurityConfig 생성
- jjwt 패키지 하위에 토큰 발급을 위한 JWTUtil , JWTFilter / 로그인-로그아웃 필터 생성
- token을 담당하는 Entity / Repository / Service / Controller
- 이메일 인증 절차 구현을 위한 Service / Controller 생성

## 변경 사항
- 없음.

## 이유
- 없음.


## 테스트 방법
1. Postman을 통해 회원가입되는 것을 확인
2. Postman을 통해 로그인시 access token 이 발급되는 것을 확인
3. h2-console 을 통해 refresh token 발급된 것을 확인
4. Postman을 통해 로그아웃 되는 것을 확인


## API 테스트 결과 

- 회원가입
<img width="744" alt="회원가입" src="https://github.com/user-attachments/assets/2652d655-9093-4dc7-aec6-92894429fd21">


- 이메일 인증
<img width="614" alt="인증 이메일 전송" src="https://github.com/user-attachments/assets/d1186bd3-653e-4114-bac5-4921d0071f98">

<img width="744" alt="이메일 인증" src="https://github.com/user-attachments/assets/3fde0651-61de-4bfc-b207-a52f2faca287">




- 로그인
<img width="744" alt="로그인" src="https://github.com/user-attachments/assets/03d3fb24-94cc-4773-ad9b-68c6d2185000">


- refresh token 발급 확인
<img width="1150" alt="리프레쉬 토큰" src="https://github.com/user-attachments/assets/01d543cf-e131-43e2-8725-e17846e3f821">


- 로그아웃
<img width="744" alt="로그아웃" src="https://github.com/user-attachments/assets/72163c4c-0f34-448b-9390-729c8962777a">


close #1 

