### PR TITLE
feature/2/회원정보 수정 , 회원탈퇴 , 임시 비밀번호 재발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorCode.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
     //일반
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
 
 
 
@@ -21,7 +22,13 @@ public enum ErrorCode {
     // 메일 인증 관련
     EMAIL_VERIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 인증에 실패했습니다."),
     EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다."),
-    EMAIL_SEND_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."); // 반드시 정의되어 있어야 함
+    EMAIL_SEND_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
+
+    // 임시 비밀번호 재발급 관련
+    PASSWORD_RESET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "비밀번호 재설정 중 오류가 발생했습니다."),
+    USER_EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 등록된 사용자를 찾을 수 없습니다."),
+    TEMP_PASSWORD_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "임시 비밀번호 생성에 실패했습니다.");
+
 
 
 

--- a/src/main/java/com/bangchef/recipe_platform/security/CustomLogoutFilter.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/CustomLogoutFilter.java
@@ -92,8 +92,8 @@ public class CustomLogoutFilter extends GenericFilterBean {
         }
 
         // 로그아웃 진행: Refresh 토큰 DB에서 제거
-        Long userId = jwtUtil.getUserId(refresh);
-        refreshTokenRepository.deleteByUserId(userId);
+        String email = jwtUtil.getEmail(refresh); // 이메일 기반으로 변경
+        refreshTokenRepository.deleteByEmail(email); // 이메일로 Refresh 토큰 삭제
 
         // Refresh 토큰 쿠키 삭제
         Cookie cookie = new Cookie("refresh", null);

--- a/src/main/java/com/bangchef/recipe_platform/security/JWTUtil.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/JWTUtil.java
@@ -31,11 +31,10 @@ public class JWTUtil {
                 .getBody();
     }
 
-
-    // User ID 추출
-    public Long getUserId(String token) {
+    // Email 추출
+    public String getEmail(String token) {
         Claims claims = getClaims(token);
-        return claims.get("userid", Long.class);
+        return claims.get("email", String.class);
     }
 
     // 토큰 타입 추출
@@ -43,7 +42,6 @@ public class JWTUtil {
         Claims claims = getClaims(token);
         return claims.get("tokenType", String.class);
     }
-
 
     // Role 추출
     public String getRole(String token) {
@@ -57,7 +55,6 @@ public class JWTUtil {
             Claims claims = getClaims(token);
             return claims.getExpiration().before(new Date());
         } catch (ExpiredJwtException e) {
-            // JWT가 만료된 경우 예외가 발생하므로, true 반환
             return true;
         }
     }
@@ -69,10 +66,10 @@ public class JWTUtil {
 
         return Jwts.builder()
                 .claim("tokenType", tokenType)
-                .claim("userid", user.getUserId())
+                .claim("email", user.getEmail()) // 이메일 기반으로 변경
                 .claim("role", role)
-                .setIssuedAt(now)  //
-                .setExpiration(expiration)  //
+                .setIssuedAt(now)
+                .setExpiration(expiration)
                 .signWith(key)
                 .compact();
     }

--- a/src/main/java/com/bangchef/recipe_platform/security/SecurityConfig.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/SecurityConfig.java
@@ -59,14 +59,15 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((auth) -> auth
 
-                        .requestMatchers("/user/**").hasAuthority("USER")
-
                         .requestMatchers(
                                 "/",
                                 "/users/logout",
                                 "/users/login",
                                 "/users/join",
-                                "users/verify/**",
+                                "/users/verify/**",
+                                "/users/reset-password",
+                                "/users/info",
+                                "/users/update",
                                 "/h2-console/**" //서브경로 포함
                         ).permitAll()
 

--- a/src/main/java/com/bangchef/recipe_platform/security/token/entity/RefreshToken.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/token/entity/RefreshToken.java
@@ -19,7 +19,11 @@ public class RefreshToken {
 
     private String expiration; // 만료시간
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private String email;
+
+    private String password;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 }

--- a/src/main/java/com/bangchef/recipe_platform/security/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/token/repository/RefreshTokenRepository.java
@@ -13,9 +13,9 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     @Modifying
     @Transactional
-    @Query("DELETE FROM RefreshToken rt WHERE rt.user.userId = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    @Query("DELETE FROM RefreshToken rt WHERE rt.user.email = :email")
+    void deleteByEmail(@Param("email") String email); // 이메일 기반 삭제 메서드 추가
 
-    boolean existsByUser_UserId(Long userId);
+    boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/bangchef/recipe_platform/security/token/service/TokenService.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/token/service/TokenService.java
@@ -53,18 +53,17 @@ public class TokenService {
         }
 
         // 유저 정보 확인 및 새로운 토큰 발급
-        Long userId = jwtUtil.getUserId(refresh);
+        String email = jwtUtil.getEmail(refresh); // Email 기반으로 변경
         String role = jwtUtil.getRole(refresh);
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+        User user = userRepository.findByEmail(email) // Email로 사용자 조회
+                .orElseThrow(() -> new RuntimeException("User not found with email: " + email));
 
         // 새로운 access 및 refresh 토큰 발급
         String newAccess = jwtUtil.createJwt("access", user, role, 600000L); // 10분
         String newRefresh = jwtUtil.createJwt("refresh", user, role, 604800000L); // 7일
 
         // 기존 refresh 토큰 삭제 후 새 토큰 저장
-        refreshTokenRepository.deleteByUserId(userId);
-        //refreshTokenRepository.deleteByRefresh(refresh);
+        refreshTokenRepository.deleteByEmail(email);
         saveRefreshToken(user, newRefresh, 604800000L); // 새로운 refresh 토큰 저장
 
         // 갱신된 토큰을 응답으로 전송

--- a/src/main/java/com/bangchef/recipe_platform/user/controller/LogoutController.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/controller/LogoutController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,7 +25,7 @@ public class LogoutController {
         this.jwtUtil = jwtUtil;
     }
 
-    @DeleteMapping("/logout")
+    @PostMapping("/logout")
     @Transactional // 트랜잭션 처리
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         String refresh = getRefreshTokenFromCookies(request);
@@ -47,8 +48,8 @@ public class LogoutController {
         }
 
         // Refresh 토큰 DB에서 제거
-        Long userId = jwtUtil.getUserId(refresh);
-        refreshTokenRepository.deleteByUserId(userId);
+        String email = jwtUtil.getEmail(refresh); // 토큰에서 이메일 추출
+        refreshTokenRepository.deleteByEmail(email); // 이메일 기반으로 삭제
 
         // 쿠키 삭제
         deleteRefreshCookie(response);

--- a/src/main/java/com/bangchef/recipe_platform/user/controller/PasswordResetController.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/controller/PasswordResetController.java
@@ -1,0 +1,30 @@
+package com.bangchef.recipe_platform.user.controller;
+
+import com.bangchef.recipe_platform.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+public class PasswordResetController {
+
+    private final UserService userService;
+
+    public PasswordResetController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<String> resetPassword(@RequestParam String email) {
+        try {
+            userService.resetPassword(email);
+            return ResponseEntity.ok("임시 비밀번호가 이메일로 발송되었습니다.");
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/controller/UserController.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/controller/UserController.java
@@ -1,0 +1,55 @@
+package com.bangchef.recipe_platform.user.controller;
+
+import com.bangchef.recipe_platform.user.dto.UserResponseDto;
+import com.bangchef.recipe_platform.user.dto.UserUpdateDto;
+import com.bangchef.recipe_platform.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/info")
+    public ResponseEntity<UserResponseDto> getMe() {
+        try {
+            UserResponseDto userResponse = userService.getLoggedInUser();
+            return ResponseEntity.ok(userResponse);
+        } catch (RuntimeException e) {
+            log.error("사용자 인증 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<UserResponseDto> updateUser(
+            @Valid @RequestBody UserUpdateDto userUpdateDto) {
+        try {
+            UserResponseDto updatedUser = userService.updateUser(userUpdateDto);
+            return ResponseEntity.ok(updatedUser);
+        } catch (RuntimeException e) {
+            log.error("사용자 업데이트 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteUser() {
+        try {
+            userService.deleteUser();
+            return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
+        } catch (RuntimeException e) {
+            log.error("회원 탈퇴 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("회원 탈퇴 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/dto/CustomUserDetails.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/dto/CustomUserDetails.java
@@ -1,6 +1,5 @@
 package com.bangchef.recipe_platform.user.dto;
 
-
 import com.bangchef.recipe_platform.user.entity.User;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -8,72 +7,57 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 @Getter
 public class CustomUserDetails implements UserDetails {
-    // User 객체를 반환하는 메서드 추가
+
     private final User user;
 
     public CustomUserDetails(User user) {
-
         this.user = user;
-
-
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(() -> user.getRole().toString());
+        return Collections.singletonList(() ->
+                Optional.ofNullable(user.getRole())
+                        .map(Object::toString)
+                        .orElse("ROLE_USER")
+        );
     }
 
     public long getUserId() {
-
         return user.getUserId();
     }
 
     @Override
     public String getPassword() {
-
         return user.getPassword();
     }
 
     @Override
     public String getUsername() {
-
-        return user.getUsername();
+        return user.getEmail(); // 이메일 기반 인증
     }
-
-    public String getEmail() {
-        return user.getEmail(); // 이메일 반환
-    }
-
-    public String getRole() {
-        return user.getRole().toString(); // 권한 반환
-    }
-
 
     @Override
     public boolean isAccountNonExpired() {
-
-        return true;
+        return true; // 계정 만료 여부 확인 가능
     }
 
     @Override
     public boolean isAccountNonLocked() {
-
-        return true;
+        return true; // 계정 잠금 여부 확인 가능
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-
-        return true;
+        return true; // 자격 증명 만료 여부 확인 가능
     }
 
     @Override
     public boolean isEnabled() {
-
-        return true;
+        return user.isEnabled(); // 사용자 활성 상태 반환
     }
-
 }

--- a/src/main/java/com/bangchef/recipe_platform/user/dto/UserResponseDto.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/dto/UserResponseDto.java
@@ -1,0 +1,19 @@
+package com.bangchef.recipe_platform.user.dto;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserResponseDto {
+    private String username;
+    private String email;
+    private String password;
+    private String profileImage;
+    private String introduction;
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/dto/UserUpdateDto.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/dto/UserUpdateDto.java
@@ -1,0 +1,27 @@
+package com.bangchef.recipe_platform.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserUpdateDto {
+
+    @NotBlank(message = "사용자 이름은 필수입니다.")
+    private String username;
+
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String password;
+
+
+    private String profileImage;
+
+    @Size(max = 200, message = "소개글은 200자 이내로 작성해주세요.")
+    private String introduction;
+}

--- a/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.bangchef.recipe_platform.user.entity;
 
 import com.bangchef.recipe_platform.common.enums.Role;
+import com.bangchef.recipe_platform.security.token.entity.RefreshToken;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,12 +9,15 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Table (name = "users")
 public class User {
 
     @Id
@@ -60,6 +64,11 @@ public class User {
 
     @Column(unique = true)
     private String verificationToken; // 이메일 인증 토큰
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<RefreshToken> refreshTokens = new ArrayList<>();
+
+
 
 //    // toString 메서드 (옵션)
 //    @Override

--- a/src/main/java/com/bangchef/recipe_platform/user/repository/UserRepository.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/repository/UserRepository.java
@@ -12,7 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByUsername(String username);
-    Optional<User> findByUserId(Long userId);
 
     Optional<User> findByVerificationToken(String token);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/bangchef/recipe_platform/user/service/CustomUserDetailsService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/CustomUserDetailsService.java
@@ -1,39 +1,25 @@
 package com.bangchef.recipe_platform.user.service;
 
-
 import com.bangchef.recipe_platform.user.dto.CustomUserDetails;
 import com.bangchef.recipe_platform.user.entity.User;
 import com.bangchef.recipe_platform.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
-    @Autowired
-    private PasswordEncoder passwordEncoder;
 
-    @Autowired
     private final UserRepository userRepository;
 
-    public CustomUserDetailsService(UserRepository userRepository) {
-
-        this.userRepository = userRepository;
-    }
-
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-
-
-        User user = userRepository.findByUsername(username)
-
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을수없습니다." + username));
-
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일로 사용자를 찾을 수 없습니다: " + email));
         return new CustomUserDetails(user);
-
     }
 }
 

--- a/src/main/java/com/bangchef/recipe_platform/user/service/EmailService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/EmailService.java
@@ -30,4 +30,20 @@ public class EmailService {
 
         mailSender.send(mimeMessage);
     }
+
+    public void sendTemporaryPasswordEmail(String recipientEmail, String tempPassword) throws MessagingException {
+        String subject = "임시 비밀번호 발급";
+        String message = "<h1>임시 비밀번호</h1>" +
+                "<p>요청하신 임시 비밀번호는 아래와 같습니다:</p>" +
+                "<p><b>" + tempPassword + "</b></p>" +
+                "<p>로그인 후 반드시 비밀번호를 변경해주세요.</p>";
+
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
+        helper.setTo(recipientEmail);
+        helper.setSubject(subject);
+        helper.setText(message, true); // HTML 형식으로 전송
+
+        mailSender.send(mimeMessage);
+    }
 }

--- a/src/main/java/com/bangchef/recipe_platform/user/service/UserService.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/service/UserService.java
@@ -1,13 +1,23 @@
 package com.bangchef.recipe_platform.user.service;
 
+import com.bangchef.recipe_platform.common.exception.CustomException;
+import com.bangchef.recipe_platform.common.exception.ErrorCode;
 import com.bangchef.recipe_platform.security.JWTUtil;
 import com.bangchef.recipe_platform.security.token.repository.RefreshTokenRepository;
+import com.bangchef.recipe_platform.user.dto.CustomUserDetails;
 import com.bangchef.recipe_platform.user.dto.LoginDto;
+import com.bangchef.recipe_platform.user.dto.UserResponseDto;
+import com.bangchef.recipe_platform.user.dto.UserUpdateDto;
 import com.bangchef.recipe_platform.user.entity.User;
 import com.bangchef.recipe_platform.user.repository.UserRepository;
+import jakarta.mail.MessagingException;
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 public class UserService {
@@ -15,16 +25,18 @@ public class UserService {
     private final BCryptPasswordEncoder passwordEncoder; // 비밀번호 암호화를 위한 인코더 추가
     private final JWTUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository; // 리프레시 토큰 저장소 추가
+    private final EmailService emailService;
 
     @Value("1")
     private Long jwtExpiration;
 
     public UserService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder,
-                       JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository) {
+                       JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository, EmailService emailService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtil = jwtUtil;
         this.refreshTokenRepository = refreshTokenRepository;
+        this.emailService = emailService;
 
     }
 
@@ -42,5 +54,103 @@ public class UserService {
         String role = user.getRole().toString();
         return jwtUtil.createJwt("access", user, role, jwtExpiration);
     }
+
+    public String generateTempPassword() {
+        return UUID.randomUUID().toString().substring(0, 8); // 8자리 임시 비밀번호 생성
+    }
+
+    public void resetPassword(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_EMAIL_NOT_FOUND));
+
+        // 임시 비밀번호 생성
+        String tempPassword;
+        try {
+            tempPassword = generateTempPassword();
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.TEMP_PASSWORD_GENERATION_FAILED);
+        }
+
+        try {
+            // 이메일 발송
+            emailService.sendTemporaryPasswordEmail(email, tempPassword);
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorCode.EMAIL_SEND_FAILURE);
+        }
+
+        // 비밀번호 암호화 후 저장
+        user.setPassword(new BCryptPasswordEncoder().encode(tempPassword));
+        userRepository.save(user);
+    }
+
+    // 현재 로그인한 사용자 정보 조회
+    public UserResponseDto getLoggedInUser() {
+        CustomUserDetails userDetails = getLoggedInUserDetails();
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return convertToUserResponseDTO(user);
+    }
+
+    // 사용자 정보 업데이트
+    public UserResponseDto updateUser(UserUpdateDto userUpdateDto) {
+        CustomUserDetails userDetails = getLoggedInUserDetails();
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        if (userUpdateDto.getUsername() != null) {
+            user.setUsername(userUpdateDto.getUsername());
+        }
+        if (userUpdateDto.getPassword() != null) {
+            user.setPassword(passwordEncoder.encode(userUpdateDto.getPassword()));
+        }
+        if (userUpdateDto.getProfileImage() != null) {
+            user.setProfileImage(userUpdateDto.getProfileImage());
+        }
+        if (userUpdateDto.getIntroduction() != null) {
+            user.setIntroduction(userUpdateDto.getIntroduction());
+        }
+
+        user = userRepository.save(user);
+        return convertToUserResponseDTO(user);
+    }
+
+    // 현재 로그인한 사용자 정보 가져오기 (SecurityContext 활용)
+    private CustomUserDetails getLoggedInUserDetails() {
+        return (CustomUserDetails) org.springframework.security.core.context.SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal();
+    }
+
+    // User 데이터를 UserResponseDTO로 변환
+    private UserResponseDto convertToUserResponseDTO(User user) {
+        UserResponseDto userResponse = new UserResponseDto();
+
+        userResponse.setUsername(user.getUsername());
+        userResponse.setEmail(user.getEmail());
+        userResponse.setPassword(user.getPassword());
+        userResponse.setProfileImage(user.getProfileImage());
+        userResponse.setIntroduction(user.getIntroduction());
+        return userResponse;
+
+    }
+
+    // 회원 탈퇴
+    public void deleteUser() {
+        CustomUserDetails userDetails = getLoggedInUserDetails();
+        String email = userDetails.getUsername();
+
+        // User 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found with email: " + email));
+
+        // RefreshToken 삭제
+        refreshTokenRepository.deleteByEmail(email);
+
+        // User 삭제
+        userRepository.delete(user);
+    }
+
 
 }


### PR DESCRIPTION
## 추가 사항
- 회원 정보를 조회/수정하는 Dto/Controller 파일 생성 , Service 로직 추가
- 임시 비밀번호를 전송하는 Service 로직 추가

## 변경 사항
- userId 를 기반으로 작동하던 로직을 email로 수정
- Table 어노테이션 테이블명 users 추가 명시

## 이유
- email로 로그인을 진행하기 때문에 userId 를 기반으로 작동하는 로직들에서 오류 발생


## 테스트 방법
1. Postman을 통해 회원정보 조회/수정되는 것을 확인
2. Postman 과 Gmail로 임시 비밀번호 발급되는 것을 확인
3. Postman을 통해 임시 비밀번호로 로그인되는 것을 확인
4. Postman을 통해 회원정보 (유저네임 / 비밀번호 / 프로필 이미지 / 소개글) 수정되는 것을 확인
5. Postman을 통해 수정된 회원정보가 조회되는 것을 확인
6. Postman을 통해 회원 탈퇴가 되는 것을 확인
7. h2-console 을 통해 회원 정보 삭제된 것을 확인


## API 테스트 결과 

- 회원 정보 최초 조회
<img width="732" alt="회원정보 최초 조회" src="https://github.com/user-attachments/assets/7b802f03-67d6-41c3-8045-a271ce2b64c8">


- 회원 정보 수정 / 수정 정보 조회
<img width="732" alt="회원정보 수정" src="https://github.com/user-attachments/assets/d9ccfd76-a66f-455c-a83c-00b5875e32d8">

<img width="732" alt="회원정보 수정후 재조회" src="https://github.com/user-attachments/assets/a55474ae-165b-421a-ab66-18b1a1973093">



- 임시 비밀번호 발급
<img width="732" alt="임시 비밀번호 전송" src="https://github.com/user-attachments/assets/229778e6-ee24-428f-8e59-83327e03515d">

<img width="732" alt="임시 비밀번호 발급" src="https://github.com/user-attachments/assets/86107bf0-a637-4139-b8a1-a9eeac164649">



- 임시 비밀번호로 로그인
<img width="732" alt="임시 비밀번호로 로그인" src="https://github.com/user-attachments/assets/f67eb33d-ea17-4433-90ad-e3a6f3c8c309">



- 회원 탈퇴
<img width="732" alt="회원 탈퇴" src="https://github.com/user-attachments/assets/42bd9a93-b724-4493-ab88-e9f1c103cbef">

<img width="834" alt="회원 정보 삭제 확인" src="https://github.com/user-attachments/assets/a457efb9-07db-4ab9-8a3e-f795cf0ce8f9">



close #3 

