### PR TITLE
[회원]

### DIFF
--- a/src/main/java/com/bangchef/recipe_platform/common/enums/ReportStatus.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/enums/ReportStatus.java
@@ -1,0 +1,7 @@
+package com.bangchef.recipe_platform.common.enums;
+
+public enum ReportStatus {
+    PENDING, // 대기 중
+    RESOLVED, // 처리됨
+    REJECTED // 거부됨
+}

--- a/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorCode.java
+++ b/src/main/java/com/bangchef/recipe_platform/common/exception/ErrorCode.java
@@ -36,7 +36,12 @@ public enum ErrorCode {
     DUPLICATE_ROLE_UPDATE_REQUEST(HttpStatus.CONFLICT, "이미 처리 중인 등업 요청이 존재합니다."),
     INVALID_ROLE_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 등업 요청입니다."),
     ALREADY_CHEF(HttpStatus.BAD_REQUEST, "사용자는 이미 CHEF입니다."),
-    INVALID_ROLE_UPDATE_STATUS(HttpStatus.BAD_REQUEST, "잘못된 등업 요청 상태입니다.");
+    INVALID_ROLE_UPDATE_STATUS(HttpStatus.BAD_REQUEST, "잘못된 등업 요청 상태입니다."),
+
+    // 신고 관련
+    REPORT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    REPORT_RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다.");
+
 
 
 

--- a/src/main/java/com/bangchef/recipe_platform/recipe/entity/Recipe.java
+++ b/src/main/java/com/bangchef/recipe_platform/recipe/entity/Recipe.java
@@ -2,6 +2,7 @@ package com.bangchef.recipe_platform.recipe.entity;
 
 import com.bangchef.recipe_platform.common.enums.Difficulty;
 import com.bangchef.recipe_platform.common.enums.RecipeCategory;
+import com.bangchef.recipe_platform.report.entity.Report;
 import com.bangchef.recipe_platform.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -69,5 +70,8 @@ public class Recipe {
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("stepNumber ASC")
     private List<CookingStep> cookingStepList = new ArrayList<>(); // 조리순서
+
+    @OneToMany(mappedBy = "reportedRecipe", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Report> reports;
 
 }

--- a/src/main/java/com/bangchef/recipe_platform/report/controller/ReportController.java
+++ b/src/main/java/com/bangchef/recipe_platform/report/controller/ReportController.java
@@ -1,0 +1,55 @@
+package com.bangchef.recipe_platform.report.controller;
+
+import com.bangchef.recipe_platform.common.exception.CustomException;
+import com.bangchef.recipe_platform.common.exception.ErrorCode;
+import com.bangchef.recipe_platform.report.dto.ReportHistoryResponseDto;
+import com.bangchef.recipe_platform.report.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    // 회원 신고
+    @PostMapping("/user")
+    public ResponseEntity<String> reportUser(@RequestBody Map<String, String> requestData) {
+        String reportedEmail = requestData.get("reportedEmail");
+        String reason = requestData.get("reason");
+
+        if (reportedEmail == null || reason == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        reportService.reportUser(reportedEmail, reason);
+        return ResponseEntity.ok("회원 신고가 접수되었습니다.");
+    }
+
+    // 게시글 신고
+    @PostMapping("/recipe")
+    public ResponseEntity<String> reportRecipe(@RequestBody Map<String, Object> requestData) {
+        Long recipeId = ((Number) requestData.get("recipeId")).longValue();
+        String reason = (String) requestData.get("reason");
+
+        if (recipeId == null || reason == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        reportService.reportRecipe(recipeId, reason);
+        return ResponseEntity.ok("게시글 신고가 접수되었습니다.");
+    }
+
+    // 신고 내역 조회
+    @GetMapping("/history")
+    public ResponseEntity<List<ReportHistoryResponseDto>> getReportHistory(@RequestParam String reporterEmail) {
+        List<ReportHistoryResponseDto> reportHistory = reportService.getReportHistory(reporterEmail);
+        return ResponseEntity.ok(reportHistory);
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/report/dto/ReportHistoryResponseDto.java
+++ b/src/main/java/com/bangchef/recipe_platform/report/dto/ReportHistoryResponseDto.java
@@ -1,0 +1,15 @@
+package com.bangchef.recipe_platform.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ReportHistoryResponseDto {
+    private String target; // 신고 대상 (회원 이메일 또는 게시글 ID)
+    private String type;   // 신고 유형 (회원 신고 / 게시글 신고)
+    private String reason; // 신고 사유
+    private String status; // 신고 상태 (대기 중 / 처리됨 / 거부됨)
+}

--- a/src/main/java/com/bangchef/recipe_platform/report/entity/Report.java
+++ b/src/main/java/com/bangchef/recipe_platform/report/entity/Report.java
@@ -1,0 +1,50 @@
+package com.bangchef.recipe_platform.report.entity;
+
+import com.bangchef.recipe_platform.common.enums.ReportStatus;
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.recipe.entity.Recipe;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter; // 신고자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = true)
+    private User reportedUser; // 신고 대상 회원 (null일 수 있음)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_recipe_id", nullable = true)
+    private Recipe reportedRecipe; // 신고 대상 게시글 (null일 수 있음)
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String reason; // 신고 사유
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReportStatus status; // 신고 상태 (PENDING, RESOLVED, REJECTED)
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 신고 날짜
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/bangchef/recipe_platform/report/repository/ReportRepository.java
+++ b/src/main/java/com/bangchef/recipe_platform/report/repository/ReportRepository.java
@@ -1,0 +1,15 @@
+package com.bangchef.recipe_platform.report.repository;
+
+import com.bangchef.recipe_platform.common.enums.ReportStatus;
+import com.bangchef.recipe_platform.report.entity.Report;
+import com.bangchef.recipe_platform.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    // 신고자를 기준으로 신고 내역 조회
+    List<Report> findAllByReporter(User reporter);
+    // 대기중 상태의 모든 신고 조회
+    List<Report> findAllByStatus(ReportStatus status);
+}

--- a/src/main/java/com/bangchef/recipe_platform/report/service/ReportService.java
+++ b/src/main/java/com/bangchef/recipe_platform/report/service/ReportService.java
@@ -1,0 +1,111 @@
+package com.bangchef.recipe_platform.report.service;
+
+import com.bangchef.recipe_platform.common.enums.ReportStatus;
+import com.bangchef.recipe_platform.report.dto.ReportHistoryResponseDto;
+import com.bangchef.recipe_platform.report.entity.Report;
+import com.bangchef.recipe_platform.report.repository.ReportRepository;
+import com.bangchef.recipe_platform.user.entity.User;
+import com.bangchef.recipe_platform.user.repository.UserRepository;
+import com.bangchef.recipe_platform.recipe.entity.Recipe;
+import com.bangchef.recipe_platform.recipe.repository.RecipeRepository;
+import com.bangchef.recipe_platform.common.exception.CustomException;
+import com.bangchef.recipe_platform.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final RecipeRepository recipeRepository;
+
+    // 회원 신고
+    public void reportUser(String reportedEmail, String reason) {
+        User reporter = getLoggedInUser();
+        User reportedUser = userRepository.findByEmail(reportedEmail)
+                .orElseThrow(() -> new CustomException(ErrorCode.REPORT_USER_NOT_FOUND));
+
+        Report report = Report.builder()
+                .reporter(reporter)
+                .reportedUser(reportedUser)
+                .reason(reason)
+                .status(ReportStatus.PENDING)
+                .build();
+
+        reportRepository.save(report);
+    }
+
+    // 게시글 신고
+    public void reportRecipe(Long recipeId, String reason) {
+        User reporter = getLoggedInUser();
+        Recipe reportedRecipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REPORT_RECIPE_NOT_FOUND));
+
+        Report report = Report.builder()
+                .reporter(reporter)
+                .reportedRecipe(reportedRecipe)
+                .reason(reason)
+                .status(ReportStatus.PENDING)
+                .build();
+
+        reportRepository.save(report);
+    }
+
+    // 사용자의 신고 내역 조회 (한국어 상태 메시지 변환 포함)
+    public List<ReportHistoryResponseDto> getReportHistory(String reporterEmail) {
+        User reporter = userRepository.findByEmail(reporterEmail)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<Report> reports = reportRepository.findAllByReporter(reporter);
+
+        return reports.stream()
+                .map(report -> new ReportHistoryResponseDto(
+                        report.getReportedUser() != null ? report.getReportedUser().getEmail() : "게시글 ID: " + report.getReportedRecipe().getId(),
+                        report.getReportedUser() != null ? "회원 신고" : "게시글 신고",
+                        report.getReason(),
+                        convertStatusToKorean(report.getStatus())
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private String convertStatusToKorean(ReportStatus status) {
+        switch (status) {
+            case PENDING:
+                return "대기 중";
+            case RESOLVED:
+                return "처리됨";
+            case REJECTED:
+                return "거부됨";
+            default:
+                return "알 수 없음";
+        }
+    }
+
+    // 관리자의 대기중인 모든 신고 내역 조회
+    public List<ReportHistoryResponseDto> getPendingReports() {
+        List<Report> reports = reportRepository.findAllByStatus(ReportStatus.PENDING);
+
+        return reports.stream()
+                .map(report -> new ReportHistoryResponseDto(
+                        report.getReportedUser() != null ? report.getReportedUser().getEmail() : "게시글 ID: " + report.getReportedRecipe().getId(),
+                        report.getReportedUser() != null ? "회원 신고" : "게시글 신고",
+                        report.getReason(),
+                        null // 상태는 필요하지 않으므로 null로 설정
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private User getLoggedInUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/bangchef/recipe_platform/security/SecurityConfig.java
+++ b/src/main/java/com/bangchef/recipe_platform/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
 
                         .requestMatchers("/users/role-update/status/**").hasAnyAuthority("USER", "CHEF")
+                        .requestMatchers("/reports/**").hasAnyAuthority("USER", "CHEF")
                         .requestMatchers("/admin/**").hasAuthority("ADMIN")
 
                         .requestMatchers(
@@ -60,6 +61,7 @@ public class SecurityConfig {
                                 "/users/update",
                                 "/recipes",
                                 "/recipes/**",
+                                "/reports/**",
                                 "/h2-console/**" //서브경로 포함
                         ).permitAll()
 

--- a/src/main/java/com/bangchef/recipe_platform/user/controller/AdminController.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/controller/AdminController.java
@@ -4,6 +4,8 @@ import com.bangchef.recipe_platform.common.enums.RequestStatus;
 import com.bangchef.recipe_platform.common.exception.CustomException;
 import com.bangchef.recipe_platform.common.exception.ErrorCode;
 import com.bangchef.recipe_platform.recipe.service.RecipeService;
+import com.bangchef.recipe_platform.report.dto.ReportHistoryResponseDto;
+import com.bangchef.recipe_platform.report.service.ReportService;
 import com.bangchef.recipe_platform.user.dto.UserResponseDto;
 import com.bangchef.recipe_platform.user.entity.User;
 import com.bangchef.recipe_platform.user.repository.UserRepository;
@@ -14,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/admin")
 public class AdminController {
@@ -21,12 +25,14 @@ public class AdminController {
     private final RoleUpdateService roleUpdateService;
     private final UserRepository userRepository;
     private final RecipeService recipeService;
+    private final ReportService reportService;
 
-    public AdminController(AdminService adminService, RoleUpdateService roleUpdateService, UserRepository userRepository, RecipeService recipeService) {
+    public AdminController(AdminService adminService, RoleUpdateService roleUpdateService, UserRepository userRepository, RecipeService recipeService, ReportService reportService) {
         this.adminService = adminService;
         this.roleUpdateService = roleUpdateService;
         this.userRepository = userRepository;
         this.recipeService = recipeService;
+        this.reportService = reportService;
     }
 
 
@@ -51,9 +57,9 @@ public class AdminController {
 
     @DeleteMapping("/users")
     @PreAuthorize("hasAuthority('ADMIN')")
-    public ResponseEntity<Void> deleteUser(@RequestParam("email") String email) {
+    public ResponseEntity<String> deleteUser(@RequestParam("email") String email) {
         adminService.deleteUser(email);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>("해당 회원의 탈퇴 처리가 완료되었습니다.", HttpStatus.OK);
     }
 
     // 관리자 : 특정 레시피 삭제
@@ -72,6 +78,14 @@ public class AdminController {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         recipeService.deleteRecipesByUser(user);
         return ResponseEntity.ok("사용자의 모든 레시피가 삭제되었습니다.");
+    }
+
+    // 신고 내역 조회
+    @GetMapping("/reports/history")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<List<ReportHistoryResponseDto>> getPendingReports() {
+        List<ReportHistoryResponseDto> pendingReports = reportService.getPendingReports();
+        return ResponseEntity.ok(pendingReports);
     }
 
 }

--- a/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
+++ b/src/main/java/com/bangchef/recipe_platform/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.bangchef.recipe_platform.user.entity;
 
 import com.bangchef.recipe_platform.common.enums.Role;
+import com.bangchef.recipe_platform.report.entity.Report;
 import com.bangchef.recipe_platform.security.token.entity.RefreshToken;
 import jakarta.persistence.*;
 import lombok.*;
@@ -74,5 +75,7 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<RefreshToken> refreshTokens = new ArrayList<>();
 
+    @OneToMany(mappedBy = "reportedUser", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Report> reportedReports;
 
 }


### PR DESCRIPTION
## 추가 사항
- 관리자 회원 탈퇴 처리시 멘트 제공하도록 로직 추가
- AdminController 신고 기능 담당하는 로직 추가 / 신고 기능 참고 필요한 reportService 주입
- ErrorCode 에 신고 기능 관련 오류 메세지 로직 추가
- 신고 기능 담당하는 entity / repository / controller / dto / service / enum 파일 생성
- SecurityConfig에 신고 관련 controller 엔드포인트에 "USER", "CHEF" 권한 부여

## 변경 사항
- User 엔티티 / Recipe 엔티티 JPA 매핑에 CascadeType.REMOVE 추가

## 이유
- 외래 키 제약 조건 문제 해결 / 관계 데이터의 자동 관리


## 테스트 방법
1. Postman을 통해 회원 / 레시피 신고 되는 것을 확인 (회원)
2. Postman을 통해 신고 목록 조회되는 것을 확인 (회원)
3. Postman을 통해 신고 목록 조회되는 것을 확인 (관리자) 
4. Postman을 통해 신고 회원 / 레시피 삭제 가능한 것을 확인 (관리자)
5. Postman을 통해 신고 처리 후 목록에서 신고 목록에서 삭제되는 것을 확인 (관리자)


## API 테스트 결과 

- 회원 / 레시피 신고 (회원)

<img width="743" alt="회원 신고" src="https://github.com/user-attachments/assets/36dc6c8c-eb48-412b-89b6-58614350c67e" />

<img width="743" alt="게시글 신고" src="https://github.com/user-attachments/assets/26f01d1e-5435-453c-aa85-2de5758d06b0" />




- 신고목록 조회 (회원)

<img width="743" alt="신고 목록 조회(회원)" src="https://github.com/user-attachments/assets/e69be5f2-b4a1-4ed5-85b6-224caf2c0626" />




- 신고목록 조회 (관리자)

<img width="756" alt="신고 목록 조회 (관리자)" src="https://github.com/user-attachments/assets/e0bc0898-c2f8-43bd-9cf1-96ba6bb8ae30" />





- 신고 회원 / 게시글 삭제 처리 (관리자)

<img width="743" alt="신고된  특정 레시피 삭제" src="https://github.com/user-attachments/assets/67515c83-9ea6-4baf-a38e-a4291e14e255" />


<img width="756" alt="신고된 회원 탈퇴 처리" src="https://github.com/user-attachments/assets/f3fe9fe8-4dfd-4724-9880-c10825e56a66" />




- 신고 처리 후 신고 목록 조회 (회원 / 관리자)

<img width="756" alt="신고 처리 후 신고목록 조회(회원)" src="https://github.com/user-attachments/assets/90d54228-9ffb-43ca-ac68-1e6ff0063d50" />

<img width="756" alt="신고 처리 후 목록 조회 (꽌리자)" src="https://github.com/user-attachments/assets/b70bd901-b1b1-4ad0-8923-3f478552cb86" />




close #13 

